### PR TITLE
Include release notes and a warning in the description.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,20 +25,17 @@ Replaces: nvidia-current-modaliases, nvidia-180-modaliases, nvidia-185-modaliase
  nvidia-96-updates, fglrx, fglrx-updates
 XB-Modaliases: ${modaliases}
 Description: Experimental NVIDIA binary Xorg driver, kernel module and VDPAU library
- The binary driver provide optimized hardware acceleration of OpenGL
- applications via a direct-rendering X Server. AGP, PCIe, SLI, TV-out
- and flat panel displays are also supported.
+ 3D-accelerated proprietary graphics driver for NVIDIA cards. May be
+ required for some newly released 3D software and games.
  .
- This package also includes the source for building the kernel module
- required by the Xorg driver, and provides NVIDIA's implementation of
- the Video Decode and presentation API. The latter enables acceleration
- for GeForce 8 and later series cards for h264 video.
+ WARNING: This is an unstable beta driver.  This package is intended for
+ testers and early adopters, and not recommended for production hardware.
  .
- GPUs such as GeForce series 6 or newer are supported.
+ Release Notes:
+ http://www.nvidia.com/object/linux-display-ia32-304.43-driver.html
  .
  See /usr/share/doc/nvidia-experimental/README.txt.gz for a complete list
  of supported GPUs and PCIIDs
- .
 
 Package: nvidia-experimental-dev
 Architecture: i386 amd64 lpia


### PR DESCRIPTION
We will make this description visible to end users via Additional
Hardware (which we don't do with the other nvidia drivers), so it gets a
more user-oriented description than normal.
