### PR TITLE
Add runtime dependency on libnvidia-egl-wayland1 (550)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+nvidia-graphics-drivers-550 (550.90.07-0ubuntu2) UNRELEASED; urgency=medium
+
+  * Add runtime dependency on libnvidia-egl-wayland1.
+    While it is technically an optional plugin, it is needed to
+    properly support wayland sessions. (LP: #2062082)
+
+ -- Alessandro Astone <alessandro.astone@canonical.com>  Tue, 02 Jul 2024 12:08:09 +0200
+
 nvidia-graphics-drivers-550 (550.90.07-0ubuntu1) oracular; urgency=medium
 
   * New upstream release (LP: #2067881)

--- a/debian/control
+++ b/debian/control
@@ -245,7 +245,8 @@ Conflicts: libnvidia-gl
 Replaces: libnvidia-gl, nvidia-384 (<< 390.25), nvidia-390 (<< 390.25-0ubuntu1)
 Provides: libnvidia-gl, libglx-vendor, libegl-vendor
 Depends:
- libnvidia-common-550, ${misc:Depends}, ${shlibs:Depends}
+ libnvidia-common-550, ${misc:Depends}, ${shlibs:Depends},
+ libnvidia-egl-wayland1
 Description: NVIDIA OpenGL/GLX/EGL/GLES GLVND libraries and Vulkan ICD
  This package provides the NVIDIA OpenGL/GLX/EGL/GLES libraries and the
  Vulkan ICD.

--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -245,7 +245,8 @@ Conflicts: libnvidia-gl
 Replaces: libnvidia-gl, nvidia-384 (<< 390.25), nvidia-390 (<< 390.25-0ubuntu1)
 Provides: libnvidia-gl, libglx-vendor, libegl-vendor
 Depends:
- libnvidia-common-#FLAVOUR#, ${misc:Depends}, ${shlibs:Depends}
+ libnvidia-common-#FLAVOUR#, ${misc:Depends}, ${shlibs:Depends},
+ libnvidia-egl-wayland1
 Description: NVIDIA OpenGL/GLX/EGL/GLES GLVND libraries and Vulkan ICD
  This package provides the NVIDIA OpenGL/GLX/EGL/GLES libraries and the
  Vulkan ICD.


### PR DESCRIPTION
While it is technically an optional plugin, it is needed to properly support wayland sessions.
https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-drivers-545/+bug/2062082

In the 470 package this happens to be a dependency already because libnvidia-vulkan-producer.so links against it.
In the newer versions instead libnvidia-vulkan-producer.so dlopens it so it is no longer automatically pulled in by ${shlibs:Depends}