### PR TITLE
Install VulkanSC icd config in the correct directory

### DIFF
--- a/debian/libnvidia-gl-560.install
+++ b/debian/libnvidia-gl-560.install
@@ -2,7 +2,7 @@ NVIDIA-Linux/_nvngx.dll                                       usr/lib/x86_64-lin
 NVIDIA-Linux/nvngx.dll                                        usr/lib/x86_64-linux-gnu/nvidia/wine
 NVIDIA-Linux/nvidia-pcc                                       usr/bin
 NVIDIA-Linux/libnvidia-vksc-core.so.560.35.03                 usr/lib/x86_64-linux-gnu
-NVIDIA-Linux/nvidia_icd_vksc.json                             usr/share/vulkan/icd.d
+NVIDIA-Linux/nvidia_icd_vksc.json                             usr/share/vulkansc/icd.d
 NVIDIA-Linux/10_nvidia.json                                usr/share/glvnd/egl_vendor.d
 NVIDIA-Linux/15_nvidia_gbm.json                            usr/share/egl/egl_external_platform.d
 NVIDIA-Linux/20_nvidia_xlib.json                           usr/share/egl/egl_external_platform.d

--- a/debian/templates/libnvidia-gl-flavour.install.in
+++ b/debian/templates/libnvidia-gl-flavour.install.in
@@ -2,7 +2,7 @@
 #AMD64_ONLY#NVIDIA-Linux/nvngx.dll                                        #LIBDIR#/nvidia/wine
 #AMD64_ONLY#NVIDIA-Linux/nvidia-pcc                                       usr/bin
 #AMD64_ONLY#NVIDIA-Linux/libnvidia-vksc-core.so.#VERSION#                 #LIBDIR#
-#AMD64_ONLY#NVIDIA-Linux/nvidia_icd_vksc.json                             usr/share/vulkan/icd.d
+#AMD64_ONLY#NVIDIA-Linux/nvidia_icd_vksc.json                             usr/share/vulkansc/icd.d
 #I386_EXCLUDED#NVIDIA-Linux/10_nvidia.json                                usr/share/glvnd/egl_vendor.d
 #I386_EXCLUDED#NVIDIA-Linux/15_nvidia_gbm.json                            usr/share/egl/egl_external_platform.d
 #I386_EXCLUDED#NVIDIA-Linux/20_nvidia_xlib.json                           usr/share/egl/egl_external_platform.d


### PR DESCRIPTION
From Nvidia's documentation:

> VulkanSC ICD (/usr/lib/libnvidia-vksc-core.so.1), which provides NVIDIA's implementation of VulkanSC. More information about VulkanSC can be found at https://www.khronos.org/vulkansc/ .
>
> Pipeline Cache Compiler (/usr/bin/nvidia-pcc), which enables offline shader compilation for VulkanSC.
>
> The VulkanSC ICD configuration file is installed as /etc/vulkansc/icd.d/nvidia_icd.json.
>
> VulkanSC support is only provided in x86_64 driver packages. Note that the VulkanSC ICD distributed in this package is intended for development purposes only, and is NOT safety certified.

This being installed under the standard Vulkan loader search path is causing crashes.

LP: #2081196