### PR TITLE
Fix i386 library names.

### DIFF
--- a/debian/templates/libnvidia-gl-flavour.install.in
+++ b/debian/templates/libnvidia-gl-flavour.install.in
@@ -39,5 +39,5 @@
 #I386_ONLY#NVIDIA-Linux/32/libnvidia-glvkspirv.so.#VERSION#               #LIBDIR#
 #I386_ONLY#NVIDIA-Linux/32/libnvidia-gpucomp.so.#VERSION#                 #LIBDIR#
 #I386_ONLY#NVIDIA-Linux/32/libnvidia-tls.so.#VERSION#                     #LIBDIR#
-#I386_ONLY#NVIDIA-Linux/32/libnvidia-egl-xcb.so.1                         #LIBDIR#
-#I386_ONLY#NVIDIA-Linux/32/libnvidia-egl-xlib.so.1                        #LIBDIR#
+#I386_ONLY#NVIDIA-Linux/32/libnvidia-egl-xcb.so.1.0.0                     #LIBDIR#
+#I386_ONLY#NVIDIA-Linux/32/libnvidia-egl-xlib.so.1.0.0                    #LIBDIR#


### PR DESCRIPTION
The ABI version numbers have changed not only for amd64 libnvidia-egl-xcb.so and libnvidia-egl-xlib.so libraries, but for i386 ones as well.