### PR TITLE
Preserve video memory on suspend/resume

### DIFF
--- a/debian/nvidia-graphics-drivers-kms.conf
+++ b/debian/nvidia-graphics-drivers-kms.conf
@@ -2,3 +2,6 @@
 # Set value to 0 to disable modesetting
 options nvidia-drm modeset=1
 
+# Preserve video memory on suspend/resume
+options nvidia NVreg_PreserveVideoMemoryAllocations=1
+options nvidia NVreg_TemporaryFilePath=/var


### PR DESCRIPTION
NVIDIA GPUs do not have self-refresh memory. Newer cards support S0ix suspend to idle but it's disabled by default (for power consumption concerns?) and also older cards just do not have this capability. So by default, NVIDIA GPUs totally shut-down during suspend, which means that when they resume all the memory content is invalidated. Parts of the linux graphics stack supports signals to instruct applications to reupload textures etc, but in most graphical toolkits this is still a work-in-progress.

Enable NVreg_PreserveVideoMemoryAllocations to instruct the driver to "swap" the GPU memory to an unnamed temporary file (unlinked inode) on suspend. Point NVreg_TemporaryFilePath to /var to create the unnamed temporary file in /var. We choose /var because it's disk-backed and it's reasonably expected to be read-writable. A tmpfs is also a good choice but it risks not being spacious enough to store the entirety of the GPU memory.

On resume the file contents are uploaded back to the GPU memory so that desktop compositors and applications can resume working with existing textures.

LP: #1876632