### PR TITLE
Add Conflicts with libnvidia-egl-gbm1

### DIFF
--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -245,7 +245,7 @@ Description: Firmware files used by the kernel module
 Package: libnvidia-gl-#FLAVOUR#
 Architecture: i386 amd64 arm64
 Multi-Arch: same
-Conflicts: libnvidia-gl
+Conflicts: libnvidia-gl, libnvidia-egl-gbm1
 Replaces: libnvidia-gl
 Provides: libnvidia-gl, libglx-vendor, libegl-vendor
 Depends:


### PR DESCRIPTION
Nvidia provides the libnvidia-egl-* libraries both as blobs and as FOSS. We ship libnvidia-egl-wayland.so.1 as a source-built package and Depends on it, but have been shipping libnvidia-egl-gbm.so.1 as a blob in libnvidia-gl, so add an explicit Conflicts statement because both packages provide the same library.

There are two other libraries libnvidia-egl-{xcb,xlib}.so.1, but those do not (yet?) have packages in Debian/Ubuntu.

LP: #2070598