### PR TITLE
Add installation of new driver libraries

### DIFF
--- a/debian/templates/libnvidia-compute-flavour.install.in
+++ b/debian/templates/libnvidia-compute-flavour.install.in
@@ -3,6 +3,7 @@
 #I386_EXCLUDED#NVIDIA-Linux/libcudadebugger.so.#VERSION#                 #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libnvidia-ml.so.#VERSION#                    #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libnvidia-nvvm.so.#VERSION#                  #LIBDIR#
+#I386_EXCLUDED#NVIDIA-Linux/libnvidia-nvvm70.so.4                        #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libnvidia-opencl.so.#VERSION#                #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/libnvidia-ptxjitcompiler.so.#VERSION#        #LIBDIR#
 #I386_EXCLUDED#NVIDIA-Linux/nvidia.icd                                   etc/OpenCL/vendors

--- a/debian/templates/libnvidia-gl-flavour.install.in
+++ b/debian/templates/libnvidia-gl-flavour.install.in
@@ -1,6 +1,8 @@
 #AMD64_ONLY#NVIDIA-Linux/_nvngx.dll                                       #LIBDIR#/nvidia/wine
 #AMD64_ONLY#NVIDIA-Linux/nvngx.dll                                        #LIBDIR#/nvidia/wine
+#AMD64_ONLY#NVIDIA-Linux/nvngx_dlssg.dll                                  #LIBDIR#/nvidia/wine
 #AMD64_ONLY#NVIDIA-Linux/nvidia-pcc                                       usr/bin
+#AMD64_ONLY#NVIDIA-Linux/libnvidia-present.so.#VERSION#                   #LIBDIR#
 #AMD64_ONLY#NVIDIA-Linux/libnvidia-vksc-core.so.#VERSION#                 #LIBDIR#
 #AMD64_ONLY#NVIDIA-Linux/nvidia_icd_vksc.json                             usr/share/vulkansc/icd.d
 #I386_EXCLUDED#NVIDIA-Linux/10_nvidia.json                                usr/share/glvnd/egl_vendor.d


### PR DESCRIPTION
- libnvidia-nvvm70.so.4 seems to be part of CUDA/OpenCL compiler.
- nvngx_dlssg.dll is a Wine DLL for DLSS frame generation.
- libnvidia-present.so is a Vulkan layer implementing NVIDIA Smooth Motion (driver-side frame generation). It is already referenced by nvidia_layers.json that is already installed.

Newer driver branches may need to be similarly updated.