### PR TITLE
Add dependencies for user space components (Jammy)

### DIFF
--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -109,6 +109,7 @@ Description: NVIDIA DKMS package
 Package: nvidia-utils-#FLAVOUR#
 Architecture: amd64 arm64
 Depends:
+ nvidia-kernel-common-#FLAVOUR# (= ${binary:Version}),
  ${shlibs:Depends}, ${misc:Depends}
 Suggests:
  nvidia-driver-#FLAVOUR#,
@@ -125,7 +126,8 @@ Package: libnvidia-compute-#FLAVOUR#
 Architecture: i386 amd64 arm64
 Multi-Arch: same
 Depends:
-  ${misc:Depends}, ${shlibs:Depends}
+ nvidia-kernel-common-#FLAVOUR# (= ${binary:Version}),
+ ${misc:Depends}, ${shlibs:Depends}
 Provides: libnvidia-compute, nvidia-opencl-icd, opencl-icd, libnvidia-ml.so.1 (= ${source:Version}),
  libnvidia-ml1 (= ${source:Version}),
  libcuda-5.0-1, libcuda-5.5-1, libcuda-6.0-1, libcuda-6.5-1,
@@ -251,7 +253,9 @@ Conflicts: libnvidia-gl
 Replaces: libnvidia-gl
 Provides: libnvidia-gl, libglx-vendor, libegl-vendor
 Depends:
- libnvidia-common-#FLAVOUR#, ${misc:Depends}, ${shlibs:Depends},
+ nvidia-kernel-common-#FLAVOUR# (= ${binary:Version}),
+ libnvidia-common-#FLAVOUR#,
+ ${misc:Depends}, ${shlibs:Depends},
  libnvidia-egl-wayland1
 Description: NVIDIA OpenGL/GLX/EGL/GLES GLVND libraries and Vulkan ICD
  This package provides the NVIDIA OpenGL/GLX/EGL/GLES libraries and the
@@ -264,6 +268,7 @@ Conflicts: libnvidia-common
 Replaces: libnvidia-common
 Provides: libnvidia-common
 Depends:
+ nvidia-kernel-common-#FLAVOUR# (= ${binary:Version}),
  ${misc:Depends}, ${shlibs:Depends}
 Description: Shared files used by the NVIDIA libraries
  This package provides a set of files that are required by the NVIDIA
@@ -277,6 +282,7 @@ Conflicts: libnvidia-extra
 Replaces: libnvidia-extra, libnvidia-common-#FLAVOUR# (<< 440.64-0ubuntu3~)
 Provides: libnvidia-extra
 Depends:
+ nvidia-kernel-common-#FLAVOUR# (= ${binary:Version}),
  ${misc:Depends}, ${shlibs:Depends}
 Description: Extra libraries for the NVIDIA Server Driver
  This package provides an additional set of libraries to be used with
@@ -308,6 +314,7 @@ Multi-Arch: same
 Pre-Depends:
  ${misc:Pre-Depends}
 Depends:
+ nvidia-kernel-common-#FLAVOUR# (= ${binary:Version}),
  ${shlibs:Depends}, ${misc:Depends}
 Provides:
  libnvidia-cfg1-any,
@@ -328,6 +335,7 @@ Multi-Arch: same
 Pre-Depends:
  ${misc:Pre-Depends}
 Depends:
+ nvidia-kernel-common-#FLAVOUR# (= ${binary:Version}),
 # ${nvidia}-alternative (= ${binary:Version}),
  ${shlibs:Depends}, ${misc:Depends}
 Provides:
@@ -350,6 +358,7 @@ Multi-Arch: same
 Pre-Depends:
  ${misc:Pre-Depends}
 Depends:
+ nvidia-kernel-common-#FLAVOUR# (= ${binary:Version}),
  libnvidia-compute-#FLAVOUR# (= ${binary:Version}),
  ${shlibs:Depends}, ${misc:Depends}
 Conflicts:
@@ -371,6 +380,7 @@ Multi-Arch: same
 Pre-Depends:
  ${misc:Pre-Depends}
 Depends:
+ nvidia-kernel-common-#FLAVOUR# (= ${binary:Version}),
  ${shlibs:Depends}, ${misc:Depends}
 Conflicts:
  libnvidia-encode,


### PR DESCRIPTION
Add dependencies for the following user space components to make them dependent on nvidia-kernel-common-#FLAVOUR#. This avoids the situation where the user/kernel can become out of sync, leading to this error:

  Failed to initialize NVML: Driver/library version mismatch
  NVML library version: 570.158

nvidia-utils-#FLAVOUR#
libnvidia-compute-#FLAVOUR#
libnvidia-gl-#FLAVOUR#
libnvidia-common-#FLAVOUR#
libnvidia-extra-#FLAVOUR#
libnvidia-cfg1-#FLAVOUR#
libnvidia-fbc1-#FLAVOUR#
libnvidia-decode-#FLAVOUR#
libnvidia-encode-#FLAVOUR#