### PR TITLE
Fix suspend crash caused by missing objtool jump_label NOP conversion

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+nvidia-graphics-drivers-595 (595.58.03-0ubuntu3) resolute; urgency=medium
+
+  * Fix suspend crash (kernel BUG at jump_label.c) caused by thunk-Kbuild.patch
+    disabling objtool on nvidia.ko and nvidia-modeset.ko, which skipped the
+    jump_label NOP conversion needed by CONFIG_HAVE_JUMP_LABEL_HACK. Add
+    dkms-objtool-jl.sh helper script invoked from the DKMS MAKE command to
+    run objtool --hacks=jump_label after module build (POST_BUILD runs too
+    late — after strip/sign/compress). (LP: #2143635)
+
+ -- Erich Eickmeyer <eeickmeyer@ubuntu.com>  Sat, 04 Apr 2026 10:05:11 -0700
+
 nvidia-graphics-drivers-595 (595.58.03-0ubuntu2) resolute; urgency=medium
 
   * control: Add transitionals for 590. (LP: #2146730)

--- a/debian/dkms-objtool-jl.sh
+++ b/debian/dkms-objtool-jl.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Run objtool --hacks=jump_label on nvidia.ko and nvidia-modeset.ko
+# Called from MAKE[0] in dkms.conf after "make modules" completes.
+#
+# Usage: dkms-objtool-jl.sh <kernel_source_dir>
+#
+# thunk-Kbuild.patch disables objtool on nvidia.o/nvidia-modeset.o to avoid
+# validation errors from pre-compiled blobs. On kernels with delay-objtool
+# (CONFIG_KLP_BUILD=y), this also skips the --hacks=jump_label pass that
+# converts static_branch JMPs to NOPs. Without this conversion, toggling
+# any static key that touches nvidia-modeset (e.g. freezer_active during
+# suspend) triggers: kernel BUG at arch/x86/kernel/jump_label.c:73
+
+OBJTOOL="$1/tools/objtool/objtool"
+
+if [ ! -x "$OBJTOOL" ]; then
+    echo "  OBJTOOL: not found, skipping jump_label fix"
+    exit 0
+fi
+
+for mod in nvidia.ko nvidia-modeset.ko; do
+    if [ -f "$mod" ]; then
+        "$OBJTOOL" --hacks=jump_label --module --link "$mod"
+        echo "  OBJTOOL [jump_label] $mod"
+    fi
+done

--- a/debian/dkms_nvidia.conf
+++ b/debian/dkms_nvidia.conf
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules && sh dkms-objtool-jl.sh $kernel_source_dir"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/dkms_nvidia_open.conf
+++ b/debian/dkms_nvidia_open.conf
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules && sh dkms-objtool-jl.sh $kernel_source_dir"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/nvidia-dkms-595-open.install
+++ b/debian/nvidia-dkms-595-open.install
@@ -1,2 +1,3 @@
 debian/open-kernel/dkms.conf                    usr/src/nvidia-595.58.03
 debian/open-kernel/patches/*                    usr/src/nvidia-595.58.03/patches
+debian/dkms-objtool-jl.sh                       usr/src/nvidia-595.58.03

--- a/debian/nvidia-dkms-595.install
+++ b/debian/nvidia-dkms-595.install
@@ -1,2 +1,3 @@
 debian/dkms.conf                    usr/src/nvidia-595.58.03
 debian/dkms_nvidia/patches/*        usr/src/nvidia-595.58.03/patches
+debian/dkms-objtool-jl.sh           usr/src/nvidia-595.58.03

--- a/debian/templates/dkms_nvidia.conf.in
+++ b/debian/templates/dkms_nvidia.conf.in
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules && sh dkms-objtool-jl.sh $kernel_source_dir"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/templates/dkms_nvidia_open.conf.in
+++ b/debian/templates/dkms_nvidia_open.conf.in
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules && sh dkms-objtool-jl.sh $kernel_source_dir"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/templates/nvidia-dkms-flavour-open.install.in
+++ b/debian/templates/nvidia-dkms-flavour-open.install.in
@@ -1,2 +1,3 @@
 debian/open-kernel/dkms.conf                    usr/src/nvidia-#VERSION#
 debian/open-kernel/patches/*                    usr/src/nvidia-#VERSION#/patches
+debian/dkms-objtool-jl.sh                       usr/src/nvidia-#VERSION#

--- a/debian/templates/nvidia-dkms-flavour.install.in
+++ b/debian/templates/nvidia-dkms-flavour.install.in
@@ -1,2 +1,3 @@
 debian/dkms.conf                    usr/src/nvidia-#VERSION#
 debian/dkms_nvidia/patches/*        usr/src/nvidia-#VERSION#/patches
+debian/dkms-objtool-jl.sh           usr/src/nvidia-#VERSION#


### PR DESCRIPTION
Add dkms-objtool-jl.sh helper script invoked from the DKMS MAKE[0]
command that runs objtool --hacks=jump_label --module --link on
nvidia.ko and nvidia-modeset.ko after 'make modules' completes.
This converts static_branch JMP instructions to NOPs, which the
kernel expects when CONFIG_HAVE_JUMP_LABEL_HACK is enabled.

Without this, suspend triggers 'jump_label: Fatal kernel bug,
unexpected op' in nvkms_kthread_q_callback and other functions that
inline try_to_freeze() -> static_branch_unlikely(&freezer_active),
resulting in a kernel BUG at arch/x86/kernel/jump_label.c:73.

The full objtool pass is disabled by thunk-Kbuild.patch because
NVIDIA's pre-compiled blobs lack -mfunction-return=thunk-extern.
On kernels with delay-objtool (CONFIG_KLP_BUILD=y, i.e. Ubuntu),
this also skips the --hacks=jump_label pass. The helper script runs
only the jump_label hack, avoiding validation errors while producing
correctly-patched modules.

The script is called from MAKE[0] rather than POST_BUILD because
DKMS runs POST_BUILD after strip/sign/compress, at which point the
.ko files have already been replaced by .ko.zst.

Affects all kernels >= 6.0 on x86_64 with CONFIG_HAVE_JUMP_LABEL_HACK=y.

References: https://github.com/NVIDIA/open-gpu-kernel-modules/issues/1095
LP: #2143635"