### PR TITLE
[SRU] Add a workaround so that DKMS builds do not fail when IBT is enabled.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Vcs-Browser: https://github.com/canonical/nvidia-graphics-drivers/tree/590
 Build-Depends:
  debhelper (>= 12),
  dpkg-dev (>= 1.17.11~),
+ quilt,
  xz-utils,
  zstd,
  dkms,

--- a/debian/dkms_nvidia.conf
+++ b/debian/dkms_nvidia.conf
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/dkms_nvidia_open.conf
+++ b/debian/dkms_nvidia_open.conf
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/patches/enable-IBT-workaround.patch
+++ b/debian/patches/enable-IBT-workaround.patch
@@ -1,0 +1,34 @@
+Description: Workaround for missing hardening in drivers
+ In order to enable CONFIG_X86_KERNEL_IBT for the NVIDIA drivers, the objtool checks must
+ be circumvented, as currently these objects are compiled without required hardening by NVIDIA,
+ and a Werror then ends the compilation. For now, we should skip these checks.
+Author: Alice C. Munduruca <alice.munduruca@canonical.com>
+Origin: other, https://forums.developer.nvidia.com/t/objtool-naked-return-found-in-mitigation-rethunk-build-with-pre-compiled-blobs-on-kernel-6-19/360610
+Bug: https://forums.developer.nvidia.com/t/objtool-naked-return-found-in-mitigation-rethunk-build-with-pre-compiled-blobs-on-kernel-6-19/360610
+Last-Update: 2026-04-07
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+Index: nvidia-graphics-drivers/NVIDIA-Linux/kernel-open/Kbuild
+===================================================================
+--- nvidia-graphics-drivers.orig/NVIDIA-Linux/kernel-open/Kbuild
++++ nvidia-graphics-drivers/NVIDIA-Linux/kernel-open/Kbuild
+@@ -304,4 +304,7 @@ $(obj)/conftest/uts_release: NV_GENERATE
+ 
+ .PHONY: NV_GENERATE_UTS_RELEASE
+ 
++$(obj)/nvidia.o: private objtool := true
++$(obj)/nvidia-modeset.o: private objtool := true
++
+ $(NV_CONFTEST_HEADERS): $(obj)/conftest/uts_release
+Index: nvidia-graphics-drivers/NVIDIA-Linux/kernel/Kbuild
+===================================================================
+--- nvidia-graphics-drivers.orig/NVIDIA-Linux/kernel/Kbuild
++++ nvidia-graphics-drivers/NVIDIA-Linux/kernel/Kbuild
+@@ -304,4 +304,7 @@ $(obj)/conftest/uts_release: NV_GENERATE
+ 
+ .PHONY: NV_GENERATE_UTS_RELEASE
+ 
++$(obj)/nvidia.o: private objtool := true
++$(obj)/nvidia-modeset.o: private objtool := true
++
+ $(NV_CONFTEST_HEADERS): $(obj)/conftest/uts_release

--- a/debian/patches/series-postunpack
+++ b/debian/patches/series-postunpack
@@ -1,0 +1,1 @@
+enable-IBT-workaround.patch

--- a/debian/rules
+++ b/debian/rules
@@ -107,7 +107,7 @@ NVIDIA-Linux-%:
 # Unpack all architectures, we may need files from all of them.
 unpack-stamp:
 	dh_testdir
-	#QUILT_PATCHES=debian/patches QUILT_SERIES=series-postunpack quilt --quiltrc /dev/null push -a || test $$? = 2
+	QUILT_PATCHES=debian/patches QUILT_SERIES=series-postunpack quilt --quiltrc /dev/null push -a || test $$? = 2
 	ls -al
 	touch $@
 

--- a/debian/templates/control.in
+++ b/debian/templates/control.in
@@ -7,6 +7,7 @@ Vcs-Browser: https://github.com/canonical/nvidia-graphics-drivers/tree/#FLAVOUR#
 Build-Depends:
  debhelper (>= 12),
  dpkg-dev (>= 1.17.11~),
+ quilt,
  xz-utils,
  zstd,
  dkms,

--- a/debian/templates/dkms_nvidia.conf.in
+++ b/debian/templates/dkms_nvidia.conf.in
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/templates/dkms_nvidia_open.conf.in
+++ b/debian/templates/dkms_nvidia_open.conf.in
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/bugs/2122077

[ Impact ]

When running a kernel with `CONFIG_X86_KERNEL_IBT` enabled, the Ubuntu-packaged NVIDIA drivers cause hangs and/or crashes due to missing support for IBT. In order to fix this issue, ensure that this option is not forced off by the make command in `dkms.conf`, and also implement a workaround for incorrect return thunks in NVIDIA-supplied binary blobs. 

[ Test Plan ]

Install a kernel with CONFIG_X86_KERNEL_IBT=y and compile the modified NVIDIA drivers. This should not generate any errors that terminate the DKMS build.

Reboot and load the NVIDIA module, at which point `nvidia-smi` should no longer cause crashes or hangs.

Test that CUDA programs run properly on the GPU. 

These changes have been tested on the testflinger machine `buzzsaw` for 590-noble.

[ Where problems could occur ]

It is possible that the objtool workaround, which was not designed for IBT, may cause issues in certains scenarios, although testing did not bring up any concerning warnings or errors in kernel logs.

[ Other Info ] 

1. https://forums.developer.nvidia.com/t/objtool-naked-return-found-in-mitigation-rethunk-build-with-pre-compiled-blobs-on-kernel-6-19/360610 