### PR TITLE
[SRU] Enable IBT for NVIDIA drivers v595 on 25.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nvidia-graphics-drivers-595 (595.58.03-0ubuntu0.25.10.2) questing; urgency=medium
+
+  * Enable IBT for NVIDIA drivers (LP: #2122077)
+  * Fix thunk build error, backport from 595-resolute
+
+ -- Alice C. Munduruca <alice.munduruca@canonical.com>  Thu, 09 Apr 2026 16:29:16 -0400
+
 nvidia-graphics-drivers-595 (595.58.03-0ubuntu0.25.10.1) questing; urgency=medium
 
   * New upstream release 595.58.03 UDA (LP: #2146730)

--- a/debian/dkms_nvidia/patches/thunk-Kbuild.patch
+++ b/debian/dkms_nvidia/patches/thunk-Kbuild.patch
@@ -1,0 +1,12 @@
+--- a/Kbuild	2026-02-24 14:28:22.879070630 +0000
++++ b/Kbuild	2026-02-24 14:09:06.055743480 +0000
+@@ -287,6 +287,9 @@
+ 
+ .PHONY: $(BUILD_SANITY_CHECKS)
+ 
++$(obj)/nvidia.o: private objtool := true
++$(obj)/nvidia-modeset.o: private objtool := true
++
+ $(BUILD_SANITY_CHECKS):
+ 	@$(NV_CONFTEST_CMD) $@ full_output
+ 

--- a/debian/dkms_nvidia/patches/thunk-Kbuild.patch
+++ b/debian/dkms_nvidia/patches/thunk-Kbuild.patch
@@ -1,11 +1,24 @@
---- a/Kbuild	2026-02-24 14:28:22.879070630 +0000
-+++ b/Kbuild	2026-02-24 14:09:06.055743480 +0000
-@@ -287,6 +287,9 @@
+diff --git a/Kbuild b/Kbuild
+index 9ec310c..dc6a4a9 100644
+--- a/Kbuild
++++ b/Kbuild
+@@ -287,6 +287,20 @@ BUILD_SANITY_CHECKS = \
  
  .PHONY: $(BUILD_SANITY_CHECKS)
  
-+$(obj)/nvidia.o: private objtool := true
-+$(obj)/nvidia-modeset.o: private objtool := true
++objtool-filtered-args = $(filter --hacks=jump_label,$(objtool-args-y))
++
++objtool-args-override = $(objtool-filtered-args) \
++        $(if $(delay-objtool), --link) \
++        $(if $(part-of-module), --module)
++
++objtool-override = $(if $(objtool-filtered-args),$(objtree)/tools/objtool/objtool,true)
++
++$(obj)/nvidia.o: private objtool-args = $(objtool-args-override)
++$(obj)/nvidia.o: private objtool = $(objtool-override)
++
++$(obj)/nvidia-modeset.o: private objtool-args = $(objtool-args-override)
++$(obj)/nvidia-modeset.o: private objtool = $(objtool-override)
 +
  $(BUILD_SANITY_CHECKS):
  	@$(NV_CONFTEST_CMD) $@ full_output

--- a/debian/open-kernel/patches/thunk-Kbuild.patch
+++ b/debian/open-kernel/patches/thunk-Kbuild.patch
@@ -1,0 +1,12 @@
+--- a/Kbuild	2026-02-24 14:28:22.879070630 +0000
++++ b/Kbuild	2026-02-24 14:09:06.055743480 +0000
+@@ -287,6 +287,9 @@
+ 
+ .PHONY: $(BUILD_SANITY_CHECKS)
+ 
++$(obj)/nvidia.o: private objtool := true
++$(obj)/nvidia-modeset.o: private objtool := true
++
+ $(BUILD_SANITY_CHECKS):
+ 	@$(NV_CONFTEST_CMD) $@ full_output
+ 

--- a/debian/open-kernel/patches/thunk-Kbuild.patch
+++ b/debian/open-kernel/patches/thunk-Kbuild.patch
@@ -1,11 +1,24 @@
---- a/Kbuild	2026-02-24 14:28:22.879070630 +0000
-+++ b/Kbuild	2026-02-24 14:09:06.055743480 +0000
-@@ -287,6 +287,9 @@
+diff --git a/Kbuild b/Kbuild
+index 9ec310c..dc6a4a9 100644
+--- a/Kbuild
++++ b/Kbuild
+@@ -287,6 +287,20 @@ BUILD_SANITY_CHECKS = \
  
  .PHONY: $(BUILD_SANITY_CHECKS)
  
-+$(obj)/nvidia.o: private objtool := true
-+$(obj)/nvidia-modeset.o: private objtool := true
++objtool-filtered-args = $(filter --hacks=jump_label,$(objtool-args-y))
++
++objtool-args-override = $(objtool-filtered-args) \
++        $(if $(delay-objtool), --link) \
++        $(if $(part-of-module), --module)
++
++objtool-override = $(if $(objtool-filtered-args),$(objtree)/tools/objtool/objtool,true)
++
++$(obj)/nvidia.o: private objtool-args = $(objtool-args-override)
++$(obj)/nvidia.o: private objtool = $(objtool-override)
++
++$(obj)/nvidia-modeset.o: private objtool-args = $(objtool-args-override)
++$(obj)/nvidia-modeset.o: private objtool = $(objtool-override)
 +
  $(BUILD_SANITY_CHECKS):
  	@$(NV_CONFTEST_CMD) $@ full_output

--- a/debian/templates/dkms_nvidia.conf.in
+++ b/debian/templates/dkms_nvidia.conf.in
@@ -14,6 +14,7 @@ DEST_MODULE_LOCATION[2]="/kernel/drivers/char/drm"
 AUTOINSTALL="yes"
 PATCH[0]="disable_fstack-clash-protection_fcf-protection.patch"
 PATCH[1]="0003-Workaround-nv_vm_flags_-calling-GPL-only-code.patch"
+PATCH[2]="thunk-Kbuild.patch"
 #PATCH[1]="buildfix_kernel_6.8-nv_drm_ioctls-DRM_UNLOCKED-is-now-the-default-behavi.patch"
 #PATCH[2]="buildfix_kernel_6.8-gpl-pfn_valid.patch"
 # Apply from v4 to v5.12 kernels

--- a/debian/templates/dkms_nvidia.conf.in
+++ b/debian/templates/dkms_nvidia.conf.in
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/templates/dkms_nvidia_open.conf.in
+++ b/debian/templates/dkms_nvidia_open.conf.in
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/templates/dkms_nvidia_open.conf.in
+++ b/debian/templates/dkms_nvidia_open.conf.in
@@ -13,6 +13,7 @@ BUILT_MODULE_NAME[2]="nvidia-drm"
 DEST_MODULE_LOCATION[2]="/kernel/drivers/char/drm"
 AUTOINSTALL="yes"
 PATCH[0]="disable_fstack-clash-protection_fcf-protection.patch"
+PATCH[1]="thunk-Kbuild.patch"
 # Apply from v4 to v5.12 kernels
 #PATCH[2]="buildfix_kernel_6.8-nv_drm_ioctls-DRM_UNLOCKED-is-now-the-default-behavi.patch"
 #PATCH[3]="buildfix_kernel_6.8-gpl-pfn_valid.patch"


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/bugs/2122077

[ Impact ]

When running a kernel with CONFIG_X86_KERNEL_IBT enabled, the Ubuntu-packaged NVIDIA drivers cause hangs and/or crashes due to missing support for IBT. In order to fix this issue, ensure that this option is not forced off by the make command in dkms.conf. So that this doesn't cause issues with CONFIG_MITIGATION_RETHUNK, also backport the thunk workaround and PR https://github.com/canonical/nvidia-graphics-drivers/pull/85 for its fix.

[ Test Plan ]

Install a kernel with CONFIG_X86_KERNEL_IBT=y and compile the modified NVIDIA drivers. This should not generate any errors that terminate the DKMS build.

Reboot and load the NVIDIA module, at which point nvidia-smi should no longer cause crashes or hangs.

Test that CUDA programs run properly on the GPU.

These changes have been tested on the testflinger machine buzzsaw for 595-questing.

[ Where problems could occur ]

It is possible that the objtool workaround and associated patching from the subsequent commit, which were not designed for IBT, may cause issues in certains scenarios. In my testing on the GB200 buzzsaw machine, no concerning warnings or errors beyond what is expected for the thunk workaround are present in kernel logs.