### PR TITLE
[SRU] Enable IBT for NVIDIA drivers v595 on 26.04/26.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nvidia-graphics-drivers-595 (595.71.05-0ubuntu2) stonking; urgency=medium
+
+  * Enable IBT for NVIDIA drivers (LP: #2122077)
+
+ -- Alice C. Munduruca <alice.munduruca@canonical.com>  Wed, 27 May 2026 16:28:25 -0400
+
 nvidia-graphics-drivers-595 (595.71.05-0ubuntu1) stonking; urgency=medium
 
   * Fix suspend crash caused by missing objtool jump_label NOP

--- a/debian/dkms_nvidia.conf
+++ b/debian/dkms_nvidia.conf
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/dkms_nvidia_open.conf
+++ b/debian/dkms_nvidia_open.conf
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/templates/dkms_nvidia.conf.in
+++ b/debian/templates/dkms_nvidia.conf.in
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"

--- a/debian/templates/dkms_nvidia_open.conf.in
+++ b/debian/templates/dkms_nvidia_open.conf.in
@@ -6,7 +6,7 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/char/drm"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE[0]="unset ARCH; [ ! -h /usr/bin/cc ] && export CC=/usr/bin/gcc; env NV_VERBOSE=1 \
-    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd CONFIG_X86_KERNEL_IBT= modules"
+    'make' -j$PROCS_NUM NV_EXCLUDE_BUILD_MODULES='#NVEXCLUDEMODULES#' KERNEL_UNAME=${kernelver} IGNORE_XEN_PRESENCE=1 IGNORE_CC_MISMATCH=1 SYSSRC=$kernel_source_dir LD=/usr/bin/ld.bfd modules"
 BUILT_MODULE_NAME[1]="nvidia-modeset"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/char/drm"
 BUILT_MODULE_NAME[2]="nvidia-drm"


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/bugs/2122077

[ Impact ]

When running a kernel with CONFIG_X86_KERNEL_IBT enabled, the Ubuntu-packaged NVIDIA drivers cause hangs and/or crashes due to missing support for IBT. In order to fix this issue, ensure that this option is not forced off by the make command in dkms.conf.

[ Test Plan ]

Install a kernel with CONFIG_X86_KERNEL_IBT=y and compile the modified NVIDIA drivers. This should not generate any errors that terminate the DKMS build.

Reboot and load the NVIDIA module, at which point nvidia-smi should no longer cause crashes or hangs.

Test that CUDA programs run properly on the GPU.

These changes have been tested on the testflinger machine buzzsaw for 595-resolute.

[ Where problems could occur ]

It is possible that the objtool workaround and associated patching from the subsequent commit, which were not designed for IBT, may cause issues in certains scenarios. In my testing on the GB200 buzzsaw machine, no concerning warnings or errors beyond what is expected for the thunk workaround are present in kernel logs.